### PR TITLE
Add smokey badge to Releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,6 +18,8 @@ categories:
       - dependencies
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
+  ![Smokey](https://github.com/vangst/smokey/workflows/CI%20Smokey/badge.svg)
+  
   ## Changes
 
   $CHANGES


### PR DESCRIPTION
Maybe this gives the developer some hesitation before cutting a release if the badging is not passing?

![Smokey](https://github.com/vangst/smokey/workflows/CI%20Smokey/badge.svg)