### PR TITLE
Create pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Closes #issue-number
+
+## What does this PR do?
+
+## How does it do?
+
+## Release requirements/notes
+
+## Checklist
+- [ ] Performed a self-review of the code
+- [ ] All relevant tests added/updated
+- [ ] Added comments in hard-to-understand areas
+- [ ] Any relevant documentation updated


### PR DESCRIPTION
This adds a PR template so as to standardize our pull requests in a way that it does not add too much overhead. It also helps someone, existing or a new hire, looking at a PR (say few months down the line) to get a quick and high level overview of the work. Furthermore, switching between issues and PR's will be more smoother once we mention the issue-number in the template. I have intentionally kept the template a short one. With time, we can definitely improve it organically. 

-----
Following is the preview of the template:

## Closes #issue-number

## What does this PR do?

## How does it do?

## Release requirements/notes

## Checklist
-  [ ] Performed a self-review of the code
- [ ] All relevant tests added/updated
- [ ] Added comments in hard-to-understand areas
- [ ] Any relevant documentation updated
